### PR TITLE
Subclass HTTPServiceError from AssertionError

### DIFF
--- a/demands/__init__.py
+++ b/demands/__init__.py
@@ -11,7 +11,7 @@ log = logging.getLogger(__name__)
 
 class HTTPServiceError(AssertionError):
     def __init__(self, response):
-        self.response = respose
+        self.response = response
         try:
             self.details = response.json()
         except ValueError:


### PR DESCRIPTION
Asked `requests` to do update their error as well:
kennethreitz/requests#1532.

So in the end: demands raises assertion errors, requests raises IO errors.

And add the request object to the error.
