### PR TITLE
requests > 2.4.2 has an optional .post json arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [Changelog](https://github.com/yola/demands/releases)
 
+## 1.0.6
+
+* Switch to version `requests` >= `2.4.2`
+
 ## 1.0.5
 
 * Allows to set max retries

--- a/demands/__init__.py
+++ b/demands/__init__.py
@@ -1,5 +1,5 @@
 __doc__ = 'Base HTTP service client'
-__version__ = '1.0.5'
+__version__ = '1.0.6'
 __url__ = 'https://github.com/yola/demands'
 
 import copy

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ mock < 2.0.0
 nose < 2.0.0
 pinocchio < 1.0.0
 python-coveralls < 3.0.0
-requests >= 1.0.0, < 2.0.0
+requests >= 2.4.2, < 3.0.0
 sphinx-bootstrap-theme < 1.0.0
 sphinxcontrib-httpdomain < 2.0.0
 testtube < 1.0.0

--- a/setup.py
+++ b/setup.py
@@ -14,5 +14,5 @@ setup(
     license='MIT (Expat)',
     url=metadata['url'],
     packages=['demands'],
-    install_requires=['requests >= 1.0.0, < 2.0.0']
+    install_requires=['requests >= 2.4.2, < 3.0.0']
 )

--- a/tests/test_demands.py
+++ b/tests/test_demands.py
@@ -53,7 +53,8 @@ class HttpServiceTests(PatchedSessionTests):
         """minimal POST request"""
         self.service.post('/post-endpoint')
         self.request.assert_called_with(
-            method='POST', url='http://service.com/post-endpoint', data=None)
+            method='POST', url='http://service.com/post-endpoint', json=None,
+            data=None)
 
     def test_minimal_put_request(self):
         """minimal PUT request"""


### PR DESCRIPTION
[Requests changelog](https://github.com/kennethreitz/requests/blob/master/HISTORY.rst)

There haven't been any huge API changes since version one of requests. We could probably support `>=1.0.0, <3.0.0`.