### PR TITLE
Use fixed "Accept" header - "application/json".

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [Changelog](https://github.com/yola/demands/releases)
 
+## 1.0.7
+
+* Use fixed "Accept" header - "application/json"
+
 ## 1.0.6
 
 * Switch to version `requests` >= `2.4.2`

--- a/demands/__init__.py
+++ b/demands/__init__.py
@@ -1,5 +1,5 @@
 __doc__ = 'Base HTTP service client'
-__version__ = '1.0.6'
+__version__ = '1.0.7'
 __url__ = 'https://github.com/yola/demands'
 
 import copy
@@ -57,6 +57,7 @@ class HTTPServiceClient(Session):
                 kwargs.get('client_name'),
                 kwargs.get('client_version', 'x.y.z'),
                 kwargs.get('app_name', 'unknown'),)
+            kwargs['headers']['Accept'] = 'application/json'
         self._shared_request_params = kwargs
 
     def _get_request_params(self, **kwargs):

--- a/tests/test_demands.py
+++ b/tests/test_demands.py
@@ -126,7 +126,8 @@ class HttpServiceTests(PatchedSessionTests):
         service.get('/test')
         self.request.assert_called_with(
             method='GET', url='http://localhost/test', allow_redirects=True,
-            headers={'User-Agent': 'my_client 1.2.3 - my_app', 'Foo': 'Bar'})
+            headers={'User-Agent': 'my_client 1.2.3 - my_app', 'Foo': 'Bar',
+                     'Accept': 'application/json'})
 
     def test_post_send_raise_exception_in_case_of_error(self):
         self.response.configure_mock(url='http://broken/', status_code=500)


### PR DESCRIPTION
Currently we have "*/*" in that header, which caused problems in UserService after Piston upgrade. Piston calls 
```
 mimeparse.best_match(...)
```

to do it's best to determine the best response format for the client. And fails :( Since we "Accept" everything, it gives us `python/pickle`.