### PR TITLE
Add Python 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
 language: python
-python:
-    - "2.6"
-    - "2.7"
+
+env:
+    - TOXENV=py27
+    - TOXENV=py33
+    - TOXENV=py34
+    - TOXENV=pypy
 install:
-    - pip install -r requirements.txt --use-mirrors
+    - pip install tox
 script:
-    - nosetests --with-coverage --cover-package=demands
+    - tox
 after_success:
     - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env:
     - TOXENV=py33
     - TOXENV=py34
     - TOXENV=pypy
+    - TOXENV=pypy3
 install:
     - pip install tox
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: python
-
+sudo: false
+cache:
+  directories:
+    - $HOME/.cache/pip
 env:
     - TOXENV=py27
     - TOXENV=py33

--- a/demands/__init__.py
+++ b/demands/__init__.py
@@ -9,6 +9,7 @@ import logging
 import time
 
 from requests import Session
+from six import iteritems, itervalues
 
 log = logging.getLogger(__name__)
 
@@ -62,7 +63,7 @@ class HTTPServiceClient(Session):
     def _get_request_params(self, **kwargs):
         """Merge shared params and new params."""
         request_params = copy.deepcopy(self._shared_request_params)
-        for key, value in kwargs.iteritems():
+        for key, value in iteritems(kwargs):
             if isinstance(value, dict) and key in request_params:
                 # ensure we don't lose dict values like headers or cookies
                 request_params[key].update(value)
@@ -115,7 +116,7 @@ class HTTPServiceClient(Session):
 
     def pre_send(self, request_params):
         """Override this method to modify sent request parameters"""
-        for adapter in self.adapters.itervalues():
+        for adapter in itervalues(self.adapters):
             adapter.max_retries = request_params.get('max_retries', 0)
         return self._format_json_request(request_params)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ nose < 2.0.0
 pinocchio < 1.0.0
 python-coveralls < 3.0.0
 requests >= 2.4.2, < 3.0.0
+six>=1.9.0
 sphinx-bootstrap-theme < 1.0.0
 sphinxcontrib-httpdomain < 2.0.0
 testtube < 1.0.0
-unittest2 < 1.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,4 @@
 [nosetests]
 with-spec=1
 spec-color=1
-with-coverage=1
 cover-package=demands

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,5 @@
 [nosetests]
 with-spec=1
 spec-color=1
+with-coverage=1
+cover-package=demands

--- a/setup.py
+++ b/setup.py
@@ -18,5 +18,9 @@ setup(
     license='MIT (Expat)',
     url=metadata['url'],
     packages=['demands'],
-    install_requires=['requests >= 2.4.2, < 3.0.0']
+    install_requires=[
+        'requests >= 2.4.2, < 3.0.0',
+        'six',
+    ],
+    test_suite='nose.collector',
 )

--- a/tests/test_demands.py
+++ b/tests/test_demands.py
@@ -1,14 +1,15 @@
 # -*- coding: utf-8 -*-
-import unittest2
 import inspect
+from unittest import TestCase
 
 from requests import Session, Response
 from mock import Mock, patch
+from six import itervalues
 
 from demands import HTTPServiceClient, HTTPServiceError
 
 
-class PatchedSessionTests(unittest2.TestCase):
+class PatchedSessionTests(TestCase):
     def setUp(self):
         # must patch inspect since it is used on Session.request, and when
         # Session.request is mocked, inspect blows up
@@ -189,14 +190,15 @@ class HttpServiceTests(PatchedSessionTests):
 
     def test_pre_send_sets_max_retries(self):
         self.service.pre_send({'max_retries': 2})
-        for adapter in self.service.adapters.itervalues():
+        for adapter in itervalues(self.service.adapters):
             self.assertEqual(adapter.max_retries, 2)
 
     def test_pre_send_defaults_max_retries_to_zero(self):
         self.service.pre_send({'max_retries': 2})
         self.service.pre_send({})
-        for adapter in self.service.adapters.itervalues():
+        for adapter in itervalues(self.service.adapters):
             self.assertEqual(adapter.max_retries, 0)
+
 
 def get_parsed_log_messages(mock_log, log_level):
     """Return the parsed log message sent to a mock log call at log_level

--- a/tox.ini
+++ b/tox.ini
@@ -7,4 +7,4 @@ deps =
 setenv =
     PYTHONPATH = {toxinidir}
 commands =
-    nosetests
+    nosetests --with-cover --cover-package=demands

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,10 @@
+[tox]
+envlist = py27, py33, py34, pypy
+
+[testenv]
+deps =
+    -rrequirements.txt
+setenv =
+    PYTHONPATH = {toxinidir}
+commands =
+    nosetests

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34, pypy
+envlist = py27, py33, py34, pypy, pypy3
 
 [testenv]
 deps =


### PR DESCRIPTION
Dropped unittest2 since only the 2.6 tests required them, and it
makes supporting Python 2 and 3 in a single codebase simpler.

Added `six` requirement so `iteritems` and `itervalues` is still
used on Python 2.

Added `tox` which makes testing multiple python versions locally a lot
easier.

Add nose's collector as the `test_suite` so people can use 
`python setup.py test` and `python setup.py nosetests`

I moved the coverage settings to `setup.cfg` to make testing more 
consistent and simpler but our internal CI adds `with-xcover` to the 
nosetests call which clashes with `setup.cfg` settings instead of 
overriding it, since the one was given via CLI and the other by
`setup.cfg`.