### PR TITLE
Make Demands work if base url param is empty.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 1.1.1
 
-* Now base URL can be empty, so user can pass full URL in path.
+* Make Demands work correctly if `path` param is empty. Don't add slash to
+  the base URL in this case.
 
 ## 1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [Changelog](https://github.com/yola/demands/releases)
 
+## 1.1.1
+
+* Now base URL can be empty, so user can pass full URL in path.
+
 ## 1.1.0
 
 * Add Python 3 support

--- a/demands/__init__.py
+++ b/demands/__init__.py
@@ -1,5 +1,5 @@
 __doc__ = 'Base HTTP service client'
-__version__ = '1.1.0'
+__version__ = '1.1.1'
 __url__ = 'https://github.com/yola/demands'
 
 import copy
@@ -81,7 +81,12 @@ class HTTPServiceClient(Session):
     def request(self, method, path, **kwargs):
         """Sends a :class:`requests.Request` and demands
            a :class:`requests.Response`."""
-        url = '%s/%s' % (self.url.rstrip('/'), path.lstrip('/'))
+
+        if self.url:
+            url = '%s/%s' % (self.url.rstrip('/'), path.lstrip('/'))
+        else:
+            url = path
+
         request_params = self._get_request_params(method=method,
                                                   url=url, **kwargs)
         request_params = self.pre_send(request_params)

--- a/demands/__init__.py
+++ b/demands/__init__.py
@@ -82,10 +82,10 @@ class HTTPServiceClient(Session):
         """Sends a :class:`requests.Request` and demands
            a :class:`requests.Response`."""
 
-        if self.url:
+        if path:
             url = '%s/%s' % (self.url.rstrip('/'), path.lstrip('/'))
         else:
-            url = path
+            url = self.url
 
         request_params = self._get_request_params(method=method,
                                                   url=url, **kwargs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 coverage < 4.0.0
 flake8 < 3.0.0
-mock < 2.0.0
+mock < 1.2.0
 funcsigs
 nose < 2.0.0
 pinocchio < 1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 coverage < 4.0.0
 flake8 < 3.0.0
-mock < 1.2.0
+mock < 2.0.0
 funcsigs
 nose < 2.0.0
 pinocchio < 1.0.0

--- a/tests/test_demands.py
+++ b/tests/test_demands.py
@@ -188,9 +188,10 @@ class HttpServiceTests(PatchedSessionTests):
             allow_redirects=True
         )
 
-    def test_url_is_composed_properly_is_base_url_is_empty(self):
-        service = HTTPServiceClient('')
-        service.get('http://service.com/some/path/get-endpoint')
+    def test_url_is_composed_properly_if_path_is_empty(self):
+        service = HTTPServiceClient(
+            'http://service.com/some/path/get-endpoint')
+        service.get('')
         self.request.assert_called_with(
             method='GET', url='http://service.com/some/path/get-endpoint',
             allow_redirects=True

--- a/tests/test_demands.py
+++ b/tests/test_demands.py
@@ -188,6 +188,14 @@ class HttpServiceTests(PatchedSessionTests):
             allow_redirects=True
         )
 
+    def test_url_is_composed_properly_is_base_url_is_empty(self):
+        service = HTTPServiceClient('')
+        service.get('http://service.com/some/path/get-endpoint')
+        self.request.assert_called_with(
+            method='GET', url='http://service.com/some/path/get-endpoint',
+            allow_redirects=True
+        )
+
     def test_pre_send_sets_max_retries(self):
         self.service.pre_send({'max_retries': 2})
         for adapter in itervalues(self.service.adapters):


### PR DESCRIPTION
* Fix incorrect URL formatting if `path` is empty. Now Demands doesn't add slash to the base URL in such case.
* Also, `Mock` requirement changed, because Mock 1.3 requires `setuptools v 1.7`.

Related to: https://github.com/yola/sitebuilder/issues/642