### PR TITLE
Add ability to set custom is_ok for _demand_success to use

### DIFF
--- a/demands/__init__.py
+++ b/demands/__init__.py
@@ -132,7 +132,7 @@ class HTTPServiceClient(Session):
 
     def _demand_success(self, response, request_params):
         expected_codes = request_params.get('expected_response_codes', [])
-        response.is_ok = response.status_code < 300
+        response.is_ok = getattr(response, "is_ok", response.status_code < 300)
         if not (response.is_ok or response.status_code in expected_codes):
             log.error(
                 'Unexpected response from %s: url: %s, code: %s, details: %s',

--- a/demands/__init__.py
+++ b/demands/__init__.py
@@ -130,10 +130,14 @@ class HTTPServiceClient(Session):
         self._demand_success(response, kwargs)
         return response
 
-    def _demand_success(self, response, request_params):
+    def successful(self, response, request_params):
+        """Override this method to define what makes a successful response"""
         expected_codes = request_params.get('expected_response_codes', [])
-        response.is_ok = getattr(response, "is_ok", response.status_code < 300)
-        if not (response.is_ok or response.status_code in expected_codes):
+        return response.is_ok or response.status_code in expected_codes
+
+    def _demand_success(self, response, request_params):
+        response.is_ok = response.status_code < 300
+        if not self.successful(response, request_params):
             log.error(
                 'Unexpected response from %s: url: %s, code: %s, details: %s',
                 self.__class__.__name__, response.url, response.status_code,


### PR DESCRIPTION
I'd like to be able to do something along these lines:

    class SlackService(HTTPServiceClient):

        def post_send(self, response, **kwargs):
            # Slack API uses message contents to indicate errors; status code is always 200
            response.is_ok = response.json()['ok']
            super(SlackService, self).post_send(response, **kwargs)

This would make that possible.