### PR TITLE
Refactor error handling to allow use by custom post_send

### DIFF
--- a/demands/__init__.py
+++ b/demands/__init__.py
@@ -15,16 +15,16 @@ log = logging.getLogger(__name__)
 
 
 class HTTPServiceError(AssertionError):
-    def __init__(self, response):
+    def __init__(self, response, client=None):
         self.response = response
         try:
             self.details = response.json()
         except ValueError:
             self.details = response.content
         super(AssertionError, self).__init__(
-            'Unexpected response from %s: url: %s, code: %s, details: %s' % (
-                self.__class__.__name__, response.url, response.status_code,
-                self.details)
+            'Unexpected response%s: url: %s, code: %s, details: %s' % (
+                'from %s' % client.__class__.__name__ if client else '',
+                response.url, response.status_code, self.details)
         )
 
 
@@ -136,4 +136,4 @@ class HTTPServiceClient(Session):
         expected_codes = request_params.get('expected_response_codes', [])
         response.is_ok = response.status_code < 300
         if not (response.is_ok or response.status_code in expected_codes):
-            raise HTTPServiceError(response)
+            raise HTTPServiceError(response, self)

--- a/demands/__init__.py
+++ b/demands/__init__.py
@@ -15,11 +15,9 @@ log = logging.getLogger(__name__)
 
 
 class HTTPServiceError(AssertionError):
-    def __init__(self, response, client=None):
+    def __init__(self, response):
         """
         :param response: the HTTP response which was deemed in error
-        :param client: (optional) the client which received the error response.
-        The class name will be included in the message.
         """
         self.response = response
         try:
@@ -27,8 +25,7 @@ class HTTPServiceError(AssertionError):
         except ValueError:
             self.details = response.content
         super(AssertionError, self).__init__(
-            'Unexpected response%s: url: %s, code: %s, details: %s' % (
-                ('from %s' % client.__class__.__name__) if client else '',
+            'Unexpected response: url: %s, code: %s, details: %s' % (
                 response.url, response.status_code, self.details)
         )
 
@@ -141,4 +138,4 @@ class HTTPServiceClient(Session):
         expected_codes = request_params.get('expected_response_codes', [])
         response.is_ok = response.status_code < 300
         if not (response.is_ok or response.status_code in expected_codes):
-            raise HTTPServiceError(response, self)
+            raise HTTPServiceError(response)

--- a/demands/__init__.py
+++ b/demands/__init__.py
@@ -16,6 +16,11 @@ log = logging.getLogger(__name__)
 
 class HTTPServiceError(AssertionError):
     def __init__(self, response, client=None):
+        """
+        :param response: the HTTP response which was deemed in error
+        :param client: (optional) the client which received the error response.
+        The class name will be included in the message.
+        """
         self.response = response
         try:
             self.details = response.json()

--- a/demands/__init__.py
+++ b/demands/__init__.py
@@ -23,7 +23,7 @@ class HTTPServiceError(AssertionError):
             self.details = response.content
         super(AssertionError, self).__init__(
             'Unexpected response%s: url: %s, code: %s, details: %s' % (
-                'from %s' % client.__class__.__name__ if client else '',
+                ('from %s' % client.__class__.__name__) if client else '',
                 response.url, response.status_code, self.details)
         )
 

--- a/demands/__init__.py
+++ b/demands/__init__.py
@@ -134,8 +134,11 @@ class HTTPServiceClient(Session):
         expected_codes = request_params.get('expected_response_codes', [])
         response.is_ok = response.status_code < 300
         if not (response.is_ok or response.status_code in expected_codes):
-            log.error(
-                'Unexpected response from %s: url: %s, code: %s, details: %s',
-                self.__class__.__name__, response.url, response.status_code,
-                response.content)
-            raise HTTPServiceError(response)
+            self.log_and_raise_error(response)
+
+    def log_and_raise_error(self, response):
+        log.error(
+            'Unexpected response from %s: url: %s, code: %s, details: %s',
+            self.__class__.__name__, response.url, response.status_code,
+            response.content)
+        raise HTTPServiceError(response)

--- a/demands/__init__.py
+++ b/demands/__init__.py
@@ -24,7 +24,7 @@ class HTTPServiceError(AssertionError):
         super(AssertionError, self).__init__(
             'Unexpected response from %s: url: %s, code: %s, details: %s' % (
                 self.__class__.__name__, response.url, response.status_code,
-                response.details)
+                self.details)
         )
 
 

--- a/demands/__init__.py
+++ b/demands/__init__.py
@@ -22,7 +22,9 @@ class HTTPServiceError(AssertionError):
         except ValueError:
             self.details = response.content
         super(AssertionError, self).__init__(
-            'code: %s, details: %s' % (response.status_code, self.details)
+            'Unexpected response from %s: url: %s, code: %s, details: %s' % (
+                self.__class__.__name__, response.url, response.status_code,
+                response.details)
         )
 
 
@@ -134,11 +136,4 @@ class HTTPServiceClient(Session):
         expected_codes = request_params.get('expected_response_codes', [])
         response.is_ok = response.status_code < 300
         if not (response.is_ok or response.status_code in expected_codes):
-            self.log_and_raise_error(response)
-
-    def log_and_raise_error(self, response):
-        log.error(
-            'Unexpected response from %s: url: %s, code: %s, details: %s',
-            self.__class__.__name__, response.url, response.status_code,
-            response.content)
-        raise HTTPServiceError(response)
+            raise HTTPServiceError(response)

--- a/tests/test_demands.py
+++ b/tests/test_demands.py
@@ -142,7 +142,7 @@ class HttpServiceTests(PatchedSessionTests):
             self.assertEqual(e.exception.code, 500)
             self.assertEqual(e.exception.details, 'content')
             self.assertTrue(e.message.startswith(
-                'Unexpected response from HTTPServiceClient: url: '
+                'Unexpected response: url: '
                 'http://broken/, code: 500, details: '
             ))
 

--- a/tests/test_demands.py
+++ b/tests/test_demands.py
@@ -148,17 +148,15 @@ class HttpServiceTests(PatchedSessionTests):
         self.service.request(
             'METHOD', 'http://notfound/', expected_response_codes=(404,))
 
-    @patch('demands.log')
-    def test_post_send_logs_errors(self, mock_log):
+    def test_post_send_logs_errors(self):
         """failed requests are logged with status code, and content"""
         self.response.configure_mock(
             status_code=500, content='content', url='http://service.com/')
-        with self.assertRaises(HTTPServiceError):
+        with self.assertRaisesRegexp(
+                HTTPServiceError,
+                'Unexpected response from HTTPServiceError: url: '
+                'http://service.com/, code: 500, details: '):
             self.service.request('METHOD', 'http://service.com/')
-        error_msg = get_parsed_log_messages(mock_log, 'error')[0]
-        self.assertIn('service.com', error_msg)
-        self.assertIn('500', error_msg)
-        self.assertIn('content', error_msg)
 
     def test_santization_of_request_parameters_removes_unknowns(self):
         lots_of_params = {

--- a/tests/test_demands.py
+++ b/tests/test_demands.py
@@ -141,22 +141,16 @@ class HttpServiceTests(PatchedSessionTests):
             self.service.request('METHOD', 'http://broken/')
             self.assertEqual(e.exception.code, 500)
             self.assertEqual(e.exception.details, 'content')
+            self.assertTrue(e.message.startswith(
+                'Unexpected response from HTTPServiceError: url: '
+                'http://broken/, code: 500, details: '
+            ))
 
     def test_post_sends_no_exception_in_case_of_expected_response_code(self):
         self.response.configure_mock(
             status_code=404, content='content', url='http://notfound/')
         self.service.request(
             'METHOD', 'http://notfound/', expected_response_codes=(404,))
-
-    def test_post_send_logs_errors(self):
-        """failed requests are logged with status code, and content"""
-        self.response.configure_mock(
-            status_code=500, content='content', url='http://service.com/')
-        with self.assertRaisesRegexp(
-                HTTPServiceError,
-                'Unexpected response from HTTPServiceError: url: '
-                'http://service.com/, code: 500, details: '):
-            self.service.request('METHOD', 'http://service.com/')
 
     def test_santization_of_request_parameters_removes_unknowns(self):
         lots_of_params = {

--- a/tests/test_demands.py
+++ b/tests/test_demands.py
@@ -142,7 +142,7 @@ class HttpServiceTests(PatchedSessionTests):
             self.assertEqual(e.exception.code, 500)
             self.assertEqual(e.exception.details, 'content')
             self.assertTrue(e.message.startswith(
-                'Unexpected response from HTTPServiceError: url: '
+                'Unexpected response from HTTPServiceClient: url: '
                 'http://broken/, code: 500, details: '
             ))
 


### PR DESCRIPTION
Alternative to https://github.com/yola/demands/pull/43

Now this can be done instead:

    class SlackService(HTTPServiceClient):
    
        def post_send(self, response, **kwargs):
            if not response.json()['ok']:
                self.log_and_raise_error(response)
            return response
