### PR TITLE
Allow user to customise definition of acceptable response

### DIFF
--- a/demands/__init__.py
+++ b/demands/__init__.py
@@ -137,5 +137,19 @@ class HTTPServiceClient(Session):
         return response
 
     def is_acceptable(self, response, request_params):
+        """
+        Override this method to create a different definition of
+        what kind of response is acceptable.
+        If `bool(the_return_value) is False` then an `HTTPServiceError`
+        will be raised.
+
+        For example, you might want to assert that the body must be empty,
+        so you could return `len(response.content) == 0`.
+
+        In the default implementation, a response is acceptable
+        if and only if the response code is either
+        less than 300 (typically 200, i.e. OK) or if it is in the
+        `expected_response_codes` parameter in the constructor.
+        """
         expected_codes = request_params.get('expected_response_codes', [])
         return response.is_ok or response.status_code in expected_codes

--- a/demands/__init__.py
+++ b/demands/__init__.py
@@ -110,7 +110,7 @@ class HTTPServiceClient(Session):
             log.debug('Authentication via HTTP auth as "%s"', auth[0])
 
         response.is_ok = response.status_code < 300
-        if not self.is_acceptable(response, **request_params):
+        if not self.is_acceptable(response, request_params):
             raise HTTPServiceError(response)
         response = self.post_send(response, **request_params)
         return response
@@ -136,6 +136,6 @@ class HTTPServiceClient(Session):
         """Override this method to modify returned response"""
         return response
 
-    def is_acceptable(self, response, **request_params):
+    def is_acceptable(self, response, request_params):
         expected_codes = request_params.get('expected_response_codes', [])
         return response.is_ok or response.status_code in expected_codes

--- a/demands/__init__.py
+++ b/demands/__init__.py
@@ -109,6 +109,9 @@ class HTTPServiceClient(Session):
         if auth:
             log.debug('Authentication via HTTP auth as "%s"', auth[0])
 
+        response.is_ok = response.status_code < 300
+        if not self.is_acceptable(response, **request_params):
+            raise HTTPServiceError(response)
         response = self.post_send(response, **request_params)
         return response
 
@@ -131,11 +134,8 @@ class HTTPServiceClient(Session):
 
     def post_send(self, response, **kwargs):
         """Override this method to modify returned response"""
-        self._demand_success(response, kwargs)
         return response
 
-    def _demand_success(self, response, request_params):
+    def is_acceptable(self, response, **request_params):
         expected_codes = request_params.get('expected_response_codes', [])
-        response.is_ok = response.status_code < 300
-        if not (response.is_ok or response.status_code in expected_codes):
-            raise HTTPServiceError(response)
+        return response.is_ok or response.status_code in expected_codes

--- a/tests/test_demands.py
+++ b/tests/test_demands.py
@@ -69,6 +69,15 @@ class HttpServiceTests(PatchedSessionTests):
         self.request.assert_called_with(
             method='DELETE', url='http://service.com/delete-endpoint')
 
+    def test_unacceptable_request(self):
+        def get():
+            self.service.get('/get-endpoint')
+        acceptable = True
+        self.service.is_acceptable = lambda *args: acceptable
+        get()
+        acceptable = False
+        self.assertRaises(HTTPServiceError, get)
+
     def test_headers_are_passed_and_overridable(self):
         service = HTTPServiceClient(
             url='http://localhost/',

--- a/tests/test_demands.py
+++ b/tests/test_demands.py
@@ -69,7 +69,7 @@ class HttpServiceTests(PatchedSessionTests):
         self.request.assert_called_with(
             method='DELETE', url='http://service.com/delete-endpoint')
 
-    def test_unacceptable_request(self):
+    def test_unacceptable_response(self):
         def get():
             self.service.get('/get-endpoint')
         acceptable = True


### PR DESCRIPTION
New take on https://github.com/yola/demands/pull/43
Based on https://github.com/yola/demands/compare/test-dont-review-this?expand=1
@RayeN 