### PR TITLE
Add pagination module and PaginatedAPIIterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [Changelog](https://github.com/yola/demands/releases)
 
+## Dev
+
+* Add PaginatedAPIIterator, helper utility for paginated service methods
+
 ## 1.2.0
 
 * Allow the user to customise the definition of an acceptable response by overriding `is_acceptable`.

--- a/demands/pagination.py
+++ b/demands/pagination.py
@@ -1,0 +1,94 @@
+from itertools import count, islice
+
+
+class PaginatedAPIIterator(object):
+    """Paginated API iterator
+
+    Provides an interator for items in a paginated function, useful for service
+    methods that return paginated results. Supports indices and slicing.
+    Negative indices are not supported.
+
+    The paginated function accepts a page and page size argument and returns
+    a page result for those arguments.
+
+        >>> def numbers(page, page_size):
+        ...    start = page * page_size
+        ...    end = start + page_size
+        ...    return range(0, 10)[start:end]
+        ...
+        >>> iterator = PaginatedAPIIterator(numbers)
+        >>> list(iterator)
+        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        >>> iterator[10]
+        9
+        >>> iterator[0:5]
+        [0, 1, 2, 3, 4]
+
+    The names of these arguments and value for page_size can be overriden by
+    extending this class:
+
+        >>> class MyPaginatedAPIIterator(PaginatedAPIIterator):
+        ...    page_parm = 'offset'
+        ...    page_size_param = 'length'
+        ...    page_size = 10
+        ...
+        >>> def numbers(offset, length):
+        ...     start = offset * length
+        ...     end = start + length
+        ...     return range(0, 100)[start:end]
+        ...
+        >>> MyPaginatedAPIIterator(numbers)
+
+    The pagination_type class variable defines how the api behaves, by default
+    this is set to 'page' which means the API should expect the page_param to
+    represent the index of the page to return. Set this value to 'item' if the
+    API expects page_parm to represent the index of an item.
+    """
+
+    page_param = 'page'
+    page_size_param = 'page_size'
+    page_size = 100
+    pagination_type = 'page'
+
+    def __init__(self, paginated_fn, args=None, kwargs=None):
+        self.paginated_fn = paginated_fn
+        self.args = tuple(args or ())
+        self.kwargs = dict(kwargs or {})
+        self.pages = {}
+
+    def __iter__(self):
+        for page in self._page_ids():
+            page = self._get_page(page)
+            for result in page:
+                yield result
+            if len(page) < self.page_size:
+                return
+
+    def __getitem__(self, i):
+        if isinstance(i, slice):
+            return list(islice(self, i.start, i.stop, i.step))
+
+        if self.pagination_type == 'page':
+            page = i / self.page_size
+            mod_i = i % self.page_size
+
+        if self.pagination_type == 'item':
+            page = i
+            mod_i = 0
+
+        return self._get_page(page)[mod_i]
+
+    def _get_page(self, page):
+        if page not in self.pages:
+            kwargs = dict(self.kwargs)
+            kwargs[self.page_param] = page
+            kwargs[self.page_size_param] = self.page_size
+            self.pages[page] = self.paginated_fn(*self.args, **kwargs)
+        return self.pages[page]
+
+    def _page_ids(self):
+        if self.pagination_type == 'page':
+            return count()
+        if self.pagination_type == 'item':
+            return count(0, self.page_size)
+        raise ValueError('Unknown pagination_type')

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,0 +1,72 @@
+from unittest import TestCase
+
+from demands.pagination import PaginatedAPIIterator
+
+
+class PagitationTestsMixin(object):
+    def test_iterate_one_undersized_page(self):
+        self.responses = list(range(5))
+        r = list(self.psc)
+        self.assertEqual(r, self.responses)
+
+    def test_iterate_multiple_full_pages(self):
+        self.responses = list(range(20))
+        r = list(self.psc)
+        self.assertEqual(r, self.responses)
+
+    def test_iterate_multiple_pages(self):
+        self.responses = list(range(25))
+        r = list(self.psc)
+        self.assertEqual(r, self.responses)
+
+    def test_get_by_index(self):
+        self.responses = list(range(25))
+        # first item
+        self.assertEqual(self.psc[0], self.responses[0])
+        # Non zero item
+        self.assertEqual(self.psc[5], self.responses[5])
+        # beyond first page item
+        self.assertEqual(self.psc[20], self.responses[20])
+
+    def test_get_by_index_raises_index_error_for_invalid_index(self):
+        self.responses = list(range(25))
+        with self.assertRaises(IndexError):
+            self.psc[len(self.responses)]
+
+    def test_get_by_slice(self):
+        self.responses = list(range(25))
+        # Same page, subset
+        self.assertEqual(self.psc[0:5], self.responses[0:5])
+        # Full page
+        self.assertEqual(self.psc[0:10], self.responses[0:10])
+        # Cross page
+        self.assertEqual(self.psc[5:20], self.responses[5:20])
+        # With step
+        self.assertEqual(self.psc[0:20:2], self.responses[0:20:2])
+
+
+class PagePaginationTest(TestCase, PagitationTestsMixin):
+    def setUp(self):
+        def get(url, page, page_size):
+            start = page * page_size
+            end = start + page_size
+            return self.responses[start:end]
+
+        self.psc = PaginatedAPIIterator(
+            get, args=('http://example.net/',))
+        self.psc.page_size = 10
+
+
+class ItemPaginationTest(TestCase, PagitationTestsMixin):
+    def setUp(self):
+        def get(url, offset, limit):
+            start = offset
+            end = start + limit
+            return self.responses[start:end]
+
+        self.psc = PaginatedAPIIterator(
+            get, args=('http://example.net/',))
+        self.psc.page_size = 10
+        self.psc.page_param = 'offset'
+        self.psc.page_size_param = 'limit'
+        self.psc.pagination_type = 'item'


### PR DESCRIPTION
Provides a helpful class to handle paginated service methods, making access to items in paginated results accessible via normal iterable mechanisms.

Shamelessly stolen and modifed from: https://github.com/yola/pycloudflare/blob/54698efcf0e6a424c5fff90f33cbd96a6d9b18b7/pycloudflare/pagination.py

re: https://github.com/yola/demands/issues/51