### PR TITLE
Add JSONServiceClient class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [Changelog](https://github.com/yola/demands/releases)
 
+## Dev
+
+* Add JSONServiceClient which deprecates usage of `send_as_json` configurations
+
 ## 1.3.1
 
 * Add MANIFEST.in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Dev
 
-* Add JSONServiceClient which deprecates usage of `send_as_json` configurations
+* Add JSONServiceClient
+* Remove `send_as_json` configuration for HTTPServiceClient
 
 ## 1.3.1
 

--- a/demands/__init__.py
+++ b/demands/__init__.py
@@ -7,6 +7,7 @@ import inspect
 import json
 import logging
 import time
+import warnings
 
 from requests import Session
 from six import iteritems, itervalues
@@ -83,9 +84,9 @@ class HTTPServiceClient(Session):
                     if key in self._VALID_REQUEST_ARGS)
 
     def request(self, method, path, **kwargs):
-        """Sends a :class:`requests.Request` and demands
-           a :class:`requests.Response`."""
-
+        """Send a :class:`requests.Request` and demand a
+        :class:`requests.Response`
+        """
         if path:
             url = '%s/%s' % (self.url.rstrip('/'), path.lstrip('/'))
         else:
@@ -116,7 +117,14 @@ class HTTPServiceClient(Session):
         return response
 
     def _format_json_request(self, request_params):
+        # TODO: This method and related class documentation should be removed
+        # upon major version change as its functionality is covered by the
+        # subclass JSONServiceClient
         if request_params.get('send_as_json') and request_params.get('data'):
+            warnings.warn(
+                'Use of `send_as_json` is deprecated in favor of using an '
+                'instance of `JSONServiceClient` or writing your own subclass',
+                DeprecationWarning)
             request_params['data'] = json.dumps(
                 request_params['data'],
                 default=str
@@ -130,6 +138,7 @@ class HTTPServiceClient(Session):
         """Override this method to modify sent request parameters"""
         for adapter in itervalues(self.adapters):
             adapter.max_retries = request_params.get('max_retries', 0)
+
         return self._format_json_request(request_params)
 
     def post_send(self, response, **kwargs):
@@ -153,3 +162,26 @@ class HTTPServiceClient(Session):
         """
         expected_codes = request_params.get('expected_response_codes', [])
         return response.is_ok or response.status_code in expected_codes
+
+
+class JSONServiceClient(HTTPServiceClient):
+    """Base JSON service client
+
+    Provides common functionality necessary to interact with JSON http apis.
+    Extends :class:`demands.HTTPServiceClient`
+    """
+    content_type = 'application/json;charset=utf-8'
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault('headers', {}).update({
+            'Content-Type': self.content_type,
+        })
+        super(JSONServiceClient, self).__init__(*args, **kwargs)
+
+    def pre_send(self, request_params):
+        request_params = super(
+            JSONServiceClient, self).pre_send(request_params)
+        if 'data' in request_params:
+            request_params['data'] = json.dumps(
+                request_params['data'], default=str)
+        return request_params

--- a/tests/test_demands.py
+++ b/tests/test_demands.py
@@ -104,17 +104,6 @@ class HttpServiceTests(PatchedSessionTests):
             method='GET', url='http://localhost/authed-endpoint',
             allow_redirects=True, auth=('foo', 'bar'))
 
-    def test_json_requests_have_formatted_data(self):
-        self.service.post(
-            '/data-endpoint', send_as_json=True,
-            data={'back': 'forth', 'forever': True, 'snowman-quote': '"☃"'})
-        data = self.request.call_args[1]['data']
-        self.assertIn('"snowman-quote": "\\"\\u2603\\""', data)
-        self.assertIn('"forever": true', data)
-        self.assertEqual(
-            self.request.call_args[1]['headers']['Content-Type'],
-            'application/json;charset=utf-8')
-
     @patch('demands.log')
     def test_logs_authentication_when_provided(self, mock_log):
         service = HTTPServiceClient(


### PR DESCRIPTION
This removes the need for the `send_as_json` configuration used in the underlying `HTTPServiceClient` definition. Marked usage of `send_as_json` as deprecated.