### PR TITLE
Support nested results

### DIFF
--- a/demands/pagination.py
+++ b/demands/pagination.py
@@ -108,7 +108,7 @@ class PaginatedAPIIterator(object):
 
     def _get_results(self, **kwargs):
         results = self.paginated_fn(*self.args, **kwargs)
-        results_key = self.options.get('results_key')
+        results_key = self.options.get(RESULTS_KEY)
         if results_key:
             results = results[results_key]
         return results

--- a/demands/pagination.py
+++ b/demands/pagination.py
@@ -5,6 +5,7 @@ PAGE_PARAM = 'page_param'
 PAGE_SIZE_PARAM = 'page_size_param'
 PAGE_SIZE = 'page_size'
 PAGINATION_TYPE = 'pagination_type'
+RESULTS_KEY = 'results_key'
 
 
 class PaginationType(object):
@@ -79,7 +80,7 @@ class PaginatedAPIIterator(object):
         PAGE_SIZE_PARAM: 'page_size',
         PAGE_SIZE: 100,
         PAGINATION_TYPE: PaginationType.PAGE,
-        'results_key': 'results',
+        RESULTS_KEY: 'results',
     }
 
     def __init__(self, paginated_fn, args=(), kwargs=None, **options):

--- a/demands/pagination.py
+++ b/demands/pagination.py
@@ -61,6 +61,19 @@ class PaginatedAPIIterator(object):
         >>> list(iterator)
         [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, ... 99]
 
+    If your paginated function returns a dict instead of a list of results,
+    you can specify a `results_key` option.
+
+
+        >>> def numbers(page, page_size):
+        ...    start = page * page_size
+        ...    end = start + page_size
+        ...    return {'results': range(0, 10)[start:end]}
+        ...
+        >>> iterator = PaginatedAPIIterator(numbers, results_key='results')
+        >>> list(iterator)
+        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+
     """
     DEFAULT_OPTIONS = {
         PAGE_PARAM: 'page',
@@ -90,7 +103,14 @@ class PaginatedAPIIterator(object):
             self.options[PAGE_PARAM]: page,
             self.options[PAGE_SIZE_PARAM]: self.options[PAGE_SIZE],
         })
-        return self.paginated_fn(*self.args, **kwargs)
+        return self._get_results(**kwargs)
+
+    def _get_results(self, **kwargs):
+        results = self.paginated_fn(*self.args, **kwargs)
+        results_key = self.options.get('results_key')
+        if results_key:
+            results = results[results_key]
+        return results
 
     def _page_ids(self):
         if self.options[PAGINATION_TYPE] == PaginationType.PAGE:

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -43,6 +43,18 @@ class PagePaginationTest(TestCase, PaginationTestsMixin):
             self.get, args=self.args, kwargs=self.kwargs, page_size=10)
 
 
+class PagePaginationTestWithNestedResults(PagePaginationTest):
+    def get(self, *args, **kwargs):
+        results = super(PagePaginationTestWithNestedResults, self).get(
+            *args, **kwargs)
+        return {'results': results}
+
+    def setUp(self):
+        self.psc = PaginatedAPIIterator(
+            self.get, args=self.args, kwargs=self.kwargs, page_size=10,
+            results_key='results')
+
+
 class ItemPaginationTest(TestCase, PaginationTestsMixin):
     def get(self, *args, **kwargs):
         start = kwargs.pop('offset')
@@ -54,3 +66,16 @@ class ItemPaginationTest(TestCase, PaginationTestsMixin):
             self.get, args=self.args, kwargs=self.kwargs, page_size=10,
             page_param='offset', page_size_param='limit',
             pagination_type=PaginationType.ITEM)
+
+
+class ItemPaginationTestWithNestedResults(ItemPaginationTest):
+    def get(self, *args, **kwargs):
+        results = super(ItemPaginationTestWithNestedResults, self).get(
+            *args, **kwargs)
+        return {'results': results}
+
+    def setUp(self):
+        self.psc = PaginatedAPIIterator(
+            self.get, args=self.args, kwargs=self.kwargs, page_size=10,
+            page_param='offset', page_size_param='limit',
+            pagination_type=PaginationType.ITEM, results_key='results')

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -40,7 +40,8 @@ class PagePaginationTest(TestCase, PaginationTestsMixin):
 
     def setUp(self):
         self.psc = PaginatedAPIIterator(
-            self.get, args=self.args, kwargs=self.kwargs, page_size=10)
+            self.get, args=self.args, kwargs=self.kwargs, page_size=10,
+            results_key=None)
 
 
 class PagePaginationTestWithNestedResults(PagePaginationTest):
@@ -51,8 +52,7 @@ class PagePaginationTestWithNestedResults(PagePaginationTest):
 
     def setUp(self):
         self.psc = PaginatedAPIIterator(
-            self.get, args=self.args, kwargs=self.kwargs, page_size=10,
-            results_key='results')
+            self.get, args=self.args, kwargs=self.kwargs, page_size=10)
 
 
 class ItemPaginationTest(TestCase, PaginationTestsMixin):
@@ -65,7 +65,7 @@ class ItemPaginationTest(TestCase, PaginationTestsMixin):
         self.psc = PaginatedAPIIterator(
             self.get, args=self.args, kwargs=self.kwargs, page_size=10,
             page_param='offset', page_size_param='limit',
-            pagination_type=PaginationType.ITEM)
+            pagination_type=PaginationType.ITEM, results_key=None)
 
 
 class ItemPaginationTestWithNestedResults(ItemPaginationTest):
@@ -78,4 +78,4 @@ class ItemPaginationTestWithNestedResults(ItemPaginationTest):
         self.psc = PaginatedAPIIterator(
             self.get, args=self.args, kwargs=self.kwargs, page_size=10,
             page_param='offset', page_size_param='limit',
-            pagination_type=PaginationType.ITEM, results_key='results')
+            pagination_type=PaginationType.ITEM)


### PR DESCRIPTION
This builds in support for our usual style of paginated endpoints which return json like:

```
    {
        'results': [...],
        'next': ...
        ...
    }
```

ping @RayeN @jslang 