### PR TITLE
Make the start page be 1 instead of 0

### DIFF
--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -33,7 +33,7 @@ class PagePaginationTest(TestCase, PaginationTestsMixin):
         page = kwargs.pop('page')
         page_size = kwargs.pop('page_size')
 
-        start = page * page_size
+        start = (page - 1) * page_size
         end = start + page_size
 
         return super(PagePaginationTest, self).get(start, end, *args, **kwargs)


### PR DESCRIPTION
1 makes sense as the starting point when talking about a list of pages
(and it's also how our endpoints at yola work)

Left 0 as the start for item-based pagination, since it's the
index/offset and not the page.

In both cases, you can change the default by init'ing the paginator with
a `start` option