### PR TITLE
Add json decoding to responses in JSONServiceClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [Changelog](https://github.com/yola/demands/releases)
 
+## Dev
+
+* Add decoding of json responses to JSONServiceClient
+
 ## 2.0.0
 
 * Add JSONServiceClient

--- a/demands/__init__.py
+++ b/demands/__init__.py
@@ -165,3 +165,9 @@ class JSONServiceClient(HTTPServiceClient):
             request_params['data'] = json.dumps(
                 request_params['data'], default=str)
         return request_params
+
+    def post_send(self, response, **kwargs):
+        response = super(JSONServiceClient, self).post_send(response, **kwargs)
+        if not response.content:
+            return None
+        return response.json()

--- a/tests/test_demands.py
+++ b/tests/test_demands.py
@@ -220,6 +220,21 @@ class JSONServiceClientTests(PatchedSessionTests):
             kwargs['headers']['Content-Type'],
             self.service.content_type)
 
+    def test_decodes_json_responses(self):
+        self.assertEqual(
+            self.service.get('/path/'), self.response.json.return_value)
+        self.response.json.assert_called_with()
+
+    def test_returns_null_for_no_content_responses(self):
+        self.response.content = b''
+        self.response.status_code = 204
+        self.assertIsNone(self.service.get('/path/'))
+
+    def test_raises_error_for_invalid_json(self):
+        self.response.json.side_effect = ValueError
+        with self.assertRaises(ValueError):
+            self.service.get('/path/')
+
 
 def get_parsed_log_messages(mock_log, log_level):
     """Return the parsed log message sent to a mock log call at log_level


### PR DESCRIPTION
From discussion had here: https://github.com/yola/yoadmin/pull/1/files/a10cc0fa8a49d2be70ded16d4ec377fdd4a886a4#r60105063

Adds functionality to `JSONServiceClient` that assumes responses are JSON decodable (except in case of 204).