### PR TITLE
Remove JSONServiceClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # [Changelog](https://github.com/yola/demands/releases)
 
+## Dev
+
+* Remove JSONServiceClient. Newest `requests` version provides functionality
+  that obviates the need for it.
+
 ## 3.0.0
 
 * Add decoding of json responses to JSONServiceClient

--- a/demands/__init__.py
+++ b/demands/__init__.py
@@ -142,32 +142,3 @@ class HTTPServiceClient(Session):
         """
         expected_codes = request_params.get('expected_response_codes', [])
         return response.is_ok or response.status_code in expected_codes
-
-
-class JSONServiceClient(HTTPServiceClient):
-    """Base JSON service client
-
-    Provides common functionality necessary to interact with JSON http apis.
-    Extends :class:`demands.HTTPServiceClient`
-    """
-    content_type = 'application/json;charset=utf-8'
-
-    def __init__(self, *args, **kwargs):
-        kwargs.setdefault('headers', {}).update({
-            'Content-Type': self.content_type,
-        })
-        super(JSONServiceClient, self).__init__(*args, **kwargs)
-
-    def pre_send(self, request_params):
-        request_params = super(
-            JSONServiceClient, self).pre_send(request_params)
-        if 'data' in request_params:
-            request_params['data'] = json.dumps(
-                request_params['data'], default=str)
-        return request_params
-
-    def post_send(self, response, **kwargs):
-        response = super(JSONServiceClient, self).post_send(response, **kwargs)
-        if not response.content:
-            return None
-        return response.json()


### PR DESCRIPTION
Not needed now that requests provides `json` argument providing same functionality

resolves: https://github.com/yola/demands/issues/65